### PR TITLE
Only swallow events when necessary

### DIFF
--- a/TranslationApp/fMain.cs
+++ b/TranslationApp/fMain.cs
@@ -714,6 +714,9 @@ namespace TranslationApp
                         if (string.IsNullOrWhiteSpace(tbEnglishText.Text))
                             tbEnglishText.Text = tbJapaneseText.Text;
                         break;
+                    case Keys.S:
+                        bSave.PerformClick();
+                        break;
                     default:
                         e.Handled = false;
                         return;

--- a/TranslationApp/fMain.cs
+++ b/TranslationApp/fMain.cs
@@ -710,7 +710,7 @@ namespace TranslationApp
                                 lbEntries.SelectedIndex -= 1;
                         }
                         break;
-                    case Keys.W:
+                    case Keys.L:
                         if (string.IsNullOrWhiteSpace(tbEnglishText.Text))
                             tbEnglishText.Text = tbJapaneseText.Text;
                         break;

--- a/TranslationApp/fMain.cs
+++ b/TranslationApp/fMain.cs
@@ -684,41 +684,45 @@ namespace TranslationApp
         {
             if (e.Control)
             {
-                if (e.KeyCode == Keys.Down)
-                    if (lbEntries.Items.Count - 1 != lbEntries.SelectedIndex)
-                        lbEntries.SelectedIndex += 1;
-
-                if (e.KeyCode == Keys.Up)
-                    if (lbEntries.SelectedIndex > 0)
-                        lbEntries.SelectedIndex -= 1;
-
-                if (e.KeyCode == Keys.W && String.IsNullOrWhiteSpace(tbEnglishText.Text))
-                    tbEnglishText.Text = tbJapaneseText.Text;
-
-                //Swallow event 
-                e.Handled = true;
-            }
-
-            if(e.Shift)
-            {
-                if (e.KeyCode == Keys.Up)
-                    if (cbFileList.SelectedIndex > 0)
-                        cbFileList.SelectedIndex -= 1;
-
-                if (e.KeyCode == Keys.Down)
-                    if (cbFileList.Items.Count - 1 != cbFileList.SelectedIndex)
-                        cbFileList.SelectedIndex += 1;
-
-                //Swallow event 
+                switch (e.KeyCode)
+                {
+                    case Keys.Down:
+                        if (e.Alt)
+                        {
+                            if (cbFileList.Items.Count - 1 != cbFileList.SelectedIndex)
+                                cbFileList.SelectedIndex += 1;
+                        }
+                        else
+                        {
+                            if (lbEntries.Items.Count - 1 != lbEntries.SelectedIndex)
+                                lbEntries.SelectedIndex += 1;
+                        }
+                        break;
+                    case Keys.Up:
+                        if (e.Alt)
+                        {
+                            if (cbFileList.SelectedIndex > 0)
+                                cbFileList.SelectedIndex -= 1;
+                        }
+                        else
+                        {
+                            if (lbEntries.SelectedIndex > 0)
+                                lbEntries.SelectedIndex -= 1;
+                        }
+                        break;
+                    case Keys.W:
+                        if (string.IsNullOrWhiteSpace(tbEnglishText.Text))
+                            tbEnglishText.Text = tbJapaneseText.Text;
+                        break;
+                    default:
+                        e.Handled = false;
+                        return;
+                }
                 e.Handled = true;
             }
         }
 
-        private void cbFileList_SelectedIndexChanged(object sender, EventArgs e)
-        {
-
-        }
     }
 }
 
-    
+


### PR DESCRIPTION
Fixes all the missing shortcuts from other controls when pressing ctrl or alt, fixes #27
This changes some shortcuts around, so the list is as follows:
| Command | Previous Combination | Current Combination|
|-----------|------------------|----------------------------|
| Move to next line | <kbd>Control</kbd> + <kbd>↓</kbd>| <kbd>Control</kbd> + <kbd>↓</kbd>|
| Move to previous line | <kbd>Control</kbd> + <kbd>↑</kbd> | <kbd>Control</kbd> + <kbd>↑</kbd> |
| Move to next xml | <kbd>Shift</kbd>  + <kbd>↓</kbd> | <kbd>Control</kbd> + <kbd>Alt</kbd>  + <kbd>↓</kbd> |
| Move to previous xml | <kbd>Shift</kbd> + <kbd>↑</kbd>  | <kbd>Control</kbd> + <kbd>Alt</kbd> + <kbd>↑</kbd>  |
| Save current xml | N/A | <kbd>Control</kbd> + <kbd>S</kbd> |
| Copy Japanese to English field | <kbd>Control</kbd> + <kbd>W</kbd> | <kbd>Control</kbd> + <kbd>L</kbd> |

Also added a save shortcut (<kbd>ctrl</kbd>+<kbd>s</kbd>) it fires the click event for the "Save XML" button, fixes #22