### PR TITLE
Copy to clipboard feature

### DIFF
--- a/TranslationApp/fMain.Designer.cs
+++ b/TranslationApp/fMain.Designer.cs
@@ -305,6 +305,7 @@ namespace TranslationApp
             this.lbEntries.DrawItem += new System.Windows.Forms.DrawItemEventHandler(this.lbEntries_DrawItem);
             this.lbEntries.MeasureItem += new System.Windows.Forms.MeasureItemEventHandler(this.lbEntries_MeasureItem);
             this.lbEntries.SelectedIndexChanged += new System.EventHandler(this.lbEntries_SelectedIndexChanged);
+            this.lbEntries.KeyDown += new System.Windows.Forms.KeyEventHandler(this.lbEntries_KeyDown);
             // 
             // lFile
             // 

--- a/TranslationApp/fMain.cs
+++ b/TranslationApp/fMain.cs
@@ -725,6 +725,50 @@ namespace TranslationApp
             }
         }
 
+        private string stripTags(string input)
+        {
+            string output = "";
+            string pattern = @"(<\w+:?\w+>)";
+            string[] result = Regex.Split(input.Replace("\r", "").Replace("\n", ""), pattern, RegexOptions.IgnoreCase).Where(x => x != "").ToArray();
+
+            string[] names = { "<Veigue>", "<Mao>", "<Eugene>", "<Annie>", "<Tytree>", "<Hilda>", "<Claire>", "<Agarte>", "<Annie (NPC)>", "<Leader>" };
+
+            foreach (string element in result)
+            {
+
+                if (element[0] == '<')
+                {
+                    if (names.Contains(element))
+                    {
+                        output += element.Substring(1, element.Length - 2);
+                    }
+                    if (element.Contains("Unk") || element.Contains("04"))
+                    {
+                        output += "〇〇〇";
+                    }
+                    if (element.Contains("nmb"))
+                    {
+                        string el = element.Substring(5, element.Length - 7);
+                        output += Convert.ToInt32(el, 16);
+                    }
+                }
+                else
+                {
+                    output += element;
+                }
+            }
+
+            return output;
+
+        }
+
+        private void lbEntries_KeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.Control && e.KeyCode == Keys.C)
+            {
+                Clipboard.SetText(stripTags(tbJapaneseText.Text));
+            }
+        }
     }
 }
 


### PR DESCRIPTION
It adds the copy to clipboard feature from #23, but needs some tweaking, so it's a draft for now.

Possible problems:
- This line here is just the available names hardcoded, so maybe we should use the .json with the tags?
https://github.com/lifebottle/TranslationApp/blob/0ee3ec9da07f64a5f89ca7d1608a749c943f662b/TranslationApp/fMain.cs#L734

- The pattern and the tag splitting are basically duplicates from the string list drawing, so maybe put that on another function?.
- Last possible problem is any problem arising from faulty logic :P

Also, this PR depends on #29 because otherwise the list never get the <kbd>Control</kbd>+<kbd>C</kbd> shortcut.