### PR TITLE
Category fixes

### DIFF
--- a/TranslationApp/fMain.cs
+++ b/TranslationApp/fMain.cs
@@ -251,6 +251,14 @@ namespace TranslationApp
         */
         private void bSave_Click(object sender, EventArgs e)
         {
+            //Update "Done" status for entries
+            //with same text on JP and EN fields
+            foreach (Entry entry in listEntries) {
+                if (entry.JapaneseText == entry.EnglishText)
+                {
+                    entry.Status = "Done";
+                }
+            }
 
             //Remove declaration
             var settings = new XmlWriterSettings

--- a/TranslationApp/fMain.cs
+++ b/TranslationApp/fMain.cs
@@ -557,6 +557,11 @@ namespace TranslationApp
 
             }
 
+            if (cbStatus.Text == "Problematic" || cbStatus.Text == "In Review")
+            {
+                return;
+            }
+
             if (tbEnglishText.Text == tbJapaneseText.Text)
             {
                 cbStatus.Text = "Done";


### PR DESCRIPTION
fixes a problem related to #10, in which entries from "problematic" or "in-review" got automatically assigned "proofreading" when checked on.
fixes #7, now the "if JP and EN fields are the same set as Done" condition is checked to all fields before saving, test if this is the correct behavior