### PR TITLE
Revert "Add back Narikiri Dungeon nodes"

### DIFF
--- a/TranslationLib/XMLFile.cs
+++ b/TranslationLib/XMLFile.cs
@@ -248,9 +248,6 @@ namespace TranslationLib
             var speakerId = entry.SpeakerId == null ? null : new XElement("SpeakerId", string.Join(",",entry.SpeakerId));
             var voiceId = entry.VoiceId == null ? null : new XElement("VoiceId", entry.VoiceId);
             var maxLength = entry.MaxLength == null ? null : new XElement("MaxLength", entry.MaxLength);
-            var structId = entry.StructId == null ? null : new XElement("StructId", entry.StructId);
-            var unknownPointer = entry.UnknownPointer == null ? null : new XElement("UnknownPointer", entry.UnknownPointer);
-
             XElement embedOffset;
 
             if (entry.EmbedOffset)
@@ -273,13 +270,12 @@ namespace TranslationLib
                 new XElement("JapaneseText", entry.JapaneseText),
                 new XElement("EnglishText", entry.EnglishText),
                 new XElement("Notes", string.IsNullOrEmpty(entry.Notes) ? null : entry.Notes),
-                elemenId,
-                structId,
                 speakerId,
-                unknownPointer,
+                elemenId,
                 bubbleId,
                 subId,
                 new XElement("Status", entry.Status)
+
             );
         }
 

--- a/TranslationLib/XMLFolder.cs
+++ b/TranslationLib/XMLFolder.cs
@@ -146,7 +146,6 @@ namespace TranslationLib
                 SpeakerId = ExtractNullableIntArray(element.Element("SpeakerId")),
                 BubbleId = ExtractNullableInt(element.Element("BubbleId")),
                 SubId = ExtractNullableInt(element.Element("SubId")),
-                StructId = ExtractNullableInt(element.Element("StructId")),
                 UnknownPointer = ExtractNullableInt(element.Element("UnknownPointer")),
                 MaxLength = ExtractNullableInt(element.Element("MaxLength"))
             };


### PR DESCRIPTION
Reverts lifebottle/TranslationApp#78 that PR wasn't intended to be merged into main as it breaks everything else.