### PR TITLE
Adds automatic project loading and update the Folderpicker

### DIFF
--- a/TranslationApp/Config.cs
+++ b/TranslationApp/Config.cs
@@ -14,10 +14,14 @@ namespace TranslationApp
         private string _lastFolderPath;
         private DateTime _lastTimeLoaded;
 
-        public GameConfig() { }
+        public GameConfig()
+        {
+            _lastTimeLoaded = DateTime.Now;
+        }
         public GameConfig(string _Game)
         {
             _game = _Game;
+            _lastTimeLoaded = DateTime.Now; // Initialize with current time
         }
         public string Game
         {

--- a/TranslationApp/fMain.cs
+++ b/TranslationApp/fMain.cs
@@ -98,22 +98,36 @@ namespace TranslationApp
             translationToolStripMenuItem.DropDownItems.AddRange(items.ToArray());
         }
 
-        private void LoadNewFolder_Click(object sender, EventArgs e)
+         private void LoadNewFolder_Click(object sender, EventArgs e)
         {
+            var previousProject = Project;
+
             ToolStripMenuItem clickedItem = (ToolStripMenuItem)sender;
             ProjectEntry pe = (ProjectEntry)clickedItem.Tag;
             LoadProjectFolder(pe.shortName, pe.folder);
-            textPreview1.ChangeImage(pe.shortName);
-            UpdateTitle(pe.fullName);
+            
+            // Only update UI if a new project was actually loaded
+            if (Project != null && Project.CurrentFolder != null && Project != previousProject)
+            {
+                textPreview1.ChangeImage(pe.shortName);
+                UpdateTitle(pe.fullName);
+            }
         }
 
         private void LoadLastFolder_Click(object sender, EventArgs e)
         {
+            var previousProject = Project;
+
             ToolStripMenuItem clickedItem = (ToolStripMenuItem)sender;
             ProjectEntry pe = (ProjectEntry)clickedItem.Tag;
             LoadLastFolder(pe.shortName);
-            textPreview1.ChangeImage(pe.shortName);
-            UpdateTitle(pe.fullName);
+            
+            // Only update UI if project was successfully loaded
+            if (Project != null && Project.CurrentFolder != null && Project != previousProject)
+            {
+                textPreview1.ChangeImage(pe.shortName);
+                UpdateTitle(pe.fullName);
+            }
         }
 
         private void openFolderToolStripMenuItem_Click(object sender, EventArgs e)

--- a/TranslationApp/fMain.cs
+++ b/TranslationApp/fMain.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.IO;
@@ -706,17 +706,36 @@ namespace TranslationApp
             return "";
         }
 
-        private void LoadProjectFolder(string gameName, string path)
+         private void LoadProjectFolder(string gameName, string path)
         {
             lbEntries.BorderStyle = BorderStyle.FixedSingle;
-            var loadedFolder = TryLoadFolder(Path.Combine(GetFolderPath(), path), gameName.Equals("NDX"));
+            
+            // Get the folder path from user
+            string selectedFolder = GetFolderPath();
+            
+            // Check if user cancelled the folder picker
+            if (string.IsNullOrEmpty(selectedFolder))
+            {
+                // User cancelled, don't proceed
+                return;
+            }
+            
+            var loadedFolder = TryLoadFolder(Path.Combine(selectedFolder, path), gameName.Equals("NDX"));
+            
+            // Check if folder loading failed
+            if (loadedFolder == null)
+            {
+                // Folder loading failed, don't proceed
+                return;
+            }
+            
             gameConfig = config.GamesConfigList.Where(x => x.Game == gameName).FirstOrDefault();
 
             if (gameConfig == null)
             {
-                GameConfig newConfig = new GameConfig();
+                GameConfig newConfig = new GameConfig(gameName);
                 newConfig.FolderPath = loadedFolder;
-                newConfig.LastFolderPath = loadedFolder;
+                newConfig.LastFolderPath = selectedFolder; // Store the parent folder, not the subfolder
                 newConfig.Game = gameName;
                 config.GamesConfigList.Add(newConfig);
                 gameConfig = config.GetGameConfig(gameName);
@@ -724,7 +743,7 @@ namespace TranslationApp
             else
             {
                 gameConfig.FolderPath = loadedFolder;
-                gameConfig.LastFolderPath = loadedFolder;
+                gameConfig.LastFolderPath = selectedFolder; // Store the parent folder, not the subfolder
                 gameConfig.Game = gameName;
             }
 
@@ -733,10 +752,10 @@ namespace TranslationApp
         }
         private void LoadLastFolder(string gameName)
         {
-            var myConfig = config.GetGameConfig(gameName);
-            if (myConfig != null)
+            var gameConfig = config.GetGameConfig(gameName);
+            if (gameConfig != null)
             {
-                TryLoadFolder(config.GetGameConfig(gameName).FolderPath, false);
+                TryLoadFolder(gameConfig.FolderPath, false);
                 gameConfig = myConfig;
                 UpdateOptionsVisibility();
             }


### PR DESCRIPTION
I was taking my time to familiarize myself with the translation application you guys have going on, I figured some small quality of life changes would be a nice way to onboard myself. lmk what you guys think!

### Changes:
- The last loaded project will now automatically load when starting up the application
- Updated folderpicker to a more standardized one
- Cancelling out of folder picker no results in errors

### Visuals:
Old folderpicker
<img width="320" height="376" alt="image" src="https://github.com/user-attachments/assets/e89f7106-cab4-40b1-b06a-b1cfc3617447" />

New folderpicker
<img width="946" height="533" alt="image" src="https://github.com/user-attachments/assets/659fd315-f33d-4104-8f0b-03387e6a468e" />